### PR TITLE
Fix: Missing CSS file in published package

### DIFF
--- a/.husky/prepublishOnly
+++ b/.husky/prepublishOnly
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
-
+set -e
 echo "Running build before publish to ensure latest changes are included..."
 npm run build

--- a/.husky/prepublishOnly
+++ b/.husky/prepublishOnly
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+echo "Running build before publish to ensure latest changes are included..."
+npm run build


### PR DESCRIPTION
Consumers couldn't import @hmhw-operations/hmhw-ui-core/dist/index.css because the build command wasn't running before npm publish, resulting in an incomplete dist folder.

Solution: Added Husky prepublishOnly hook that automatically runs npm run build before every publish. This ensures the dist folder contains all compiled assets before the package is published.